### PR TITLE
Add be_multitenant_on rspec matcher

### DIFF
--- a/lib/rails_multitenant.rb
+++ b/lib/rails_multitenant.rb
@@ -3,3 +3,5 @@ require 'active_record'
 
 require "rails_multitenant/global_context_registry"
 require "rails_multitenant/multitenant_model"
+
+# rails_multitenant/rspec has to be explicitly included by clients who want to use it

--- a/lib/rails_multitenant/rspec.rb
+++ b/lib/rails_multitenant/rspec.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define(:be_multitenant_on) do |expected|
+  match do |actual|
+    actual.context_entity_id_field == expected
+  end
+end

--- a/spec/be_multitenant_on_matcher_spec.rb
+++ b/spec/be_multitenant_on_matcher_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+require 'rails_multitenant/rspec'
+
+describe "be_multitenant_on matcher" do
+  it "accepts a valid context field id" do
+    expect(ExternalItem).to be_multitenant_on(:external_organization_id)
+  end
+
+  it "rejects an invalid context field id" do
+    expect(ExternalItem).not_to be_multitenant_on(:other_field)
+  end
+end


### PR DESCRIPTION
This PR adds an rspec matcher so users of the gem can write assertions like this:

```ruby
expect(Rule).to be_multitenant_on(:organization_id)
```

The matcher is not loaded by default so clients wishing to use it will have to require `rails_multitenant/rspec`.

@brea9482 - mind taking a quick look?
