### PR TITLE
Add registry arg to RailsMultitenant::GlobalContextRegistry#new_registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-### 0.3.0
+### 0.3.0 (unreleased)
 * Modify `RailsMultitenant::GlobalContextRegistry#new_registry` to accept an arg
   specifying the new registry to set. The previous registry is still returned.
 
-### 0.2.0 (unreleased)
+### 0.2.0
 * Merged [PR 2](https://github.com/salsify/rails-multitenant/pull/2) which adds support for 
   multi-tenancy based on a foreign key to an external model. As part of this the `multitenant_model_on`
   method was renamed to `multitenant_on_model`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.3.0
+* Modify `RailsMultitenant::GlobalContextRegistry#new_registry` to accept an arg
+  specifying the new registry to set. The previous registry is still returned.
+
 ### 0.2.0 (unreleased)
 * Merged [PR 2](https://github.com/salsify/rails-multitenant/pull/2) which adds support for 
   multi-tenancy based on a foreign key to an external model. As part of this the `multitenant_model_on`

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -175,10 +175,10 @@ module RailsMultitenant
     # Note: these methods are intended for use in a manner like .with_isolated_registry,
     # but in contexts where around semantics are not allowed.
 
-    # Set a new, empty registry, returning the previous one.
-    def new_registry
+    # Set a new, by default empty registry, returning the previous one.
+    def new_registry(registry = {})
       priors = globals
-      self.globals = {}
+      self.globals = registry
       priors
     end
 

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -164,8 +164,7 @@ module RailsMultitenant
 
     # Run a block of code with an the given registry
     def with_isolated_registry(registry = {})
-      prior_globals = globals
-      self.globals = registry
+      prior_globals = new_registry(registry)
       yield
     ensure
       self.globals = prior_globals

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,3 +1,3 @@
 module RailsMultitenant
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/spec/global_context_registry_spec.rb
+++ b/spec/global_context_registry_spec.rb
@@ -50,7 +50,7 @@ describe GlobalContextRegistry do
     let!(:old_registry) { GlobalContextRegistry.new_registry }
 
     specify do
-      expect(old_registry).to eq ({ foo: 'bar' })
+      expect(old_registry).to eq({ foo: 'bar' })
     end
     specify do
       expect(GlobalContextRegistry.get(:foo)).to be_nil
@@ -58,6 +58,20 @@ describe GlobalContextRegistry do
     specify do
       GlobalContextRegistry.replace_registry(old_registry)
       expect(GlobalContextRegistry.get(:foo)).to eq 'bar'
+    end
+
+    context 'when a new registry is specified' do
+      let!(:old_registry) { GlobalContextRegistry.new_registry(bar: 'foo') }
+
+      specify do
+        expect(old_registry).to eq({ foo: 'bar' })
+      end
+      specify do
+        expect(GlobalContextRegistry.get(:foo)).to be_nil
+      end
+      specify do
+        expect(GlobalContextRegistry.get(:bar)).to eq 'foo'
+      end
     end
   end
 


### PR DESCRIPTION
Add registry arg to `#new_registry`. This allows the previous registry to be captured and replaced in a single line.

Bump version 0.3.0.

The README is not updated because `new_registry`/`replace_registry` are not mentioned there currently, presumably because `with_isolated_registry` is preferred.

Prime: @jturkel 