### PR TITLE
Fix be_multitenant_on matcher 

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--color
+--format documentation
+--require spec_helper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-### 0.3.1 (unreleased)
+### 0.3.2 (unreleased)
+* Fix be_multitenant_on matcher to handle models that don't include the `RailsMultitenant::MultitenantModel` module.
+
+### 0.3.1
 * Fix strip_<entity>_scope
 
 ### 0.3.0

--- a/lib/rails_multitenant/rspec.rb
+++ b/lib/rails_multitenant/rspec.rb
@@ -1,5 +1,5 @@
 RSpec::Matchers.define(:be_multitenant_on) do |expected|
   match do |actual|
-    actual.context_entity_id_field == expected
+    actual.respond_to?(:context_entity_id_field) && actual.context_entity_id_field == expected
   end
 end

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,3 +1,3 @@
 module RailsMultitenant
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/spec/be_multitenant_on_matcher_spec.rb
+++ b/spec/be_multitenant_on_matcher_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'rails_multitenant/rspec'
 
 describe "be_multitenant_on matcher" do
@@ -8,5 +7,9 @@ describe "be_multitenant_on matcher" do
 
   it "rejects an invalid context field id" do
     expect(ExternalItem).not_to be_multitenant_on(:other_field)
+  end
+
+  it "rejects classes that don't have a context field id" do
+    expect(String).not_to be_multitenant_on(:other_field)
   end
 end

--- a/spec/external_item_spec.rb
+++ b/spec/external_item_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 include RailsMultitenant
 
 describe ExternalItem do

--- a/spec/global_context_registry_spec.rb
+++ b/spec/global_context_registry_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 include RailsMultitenant
 
 describe GlobalContextRegistry do

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -2,8 +2,6 @@
 # Create an item in each
 # Make sure you can only see one org's item in one org
 
-require 'spec_helper'
-
 describe Item do
 
   let!(:item1) { Item.create! }


### PR DESCRIPTION
Fix `be_multitenant_on matcher` to handle models that don't include the `RailsMultitenant::MultitenantModel` module. I also updated the `.rspec` file so we don't need to require `spec_helper` in all our tests.

@pietdaniel - you're prime