### PR TITLE
Drop Rails 3.2 and 4.1 support and add Rails 5.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 sudo: false
 env:
-  - RAILS_VERSION="~> 3.2.22"
-  - RAILS_VERSION="~> 4.0.13"
-  - RAILS_VERSION="~> 4.1.13"
-  - RAILS_VERSION="~> 4.2.4"
+  - RAILS_VERSION="~> 4.1.16"
+  - RAILS_VERSION="~> 4.2.7"
+  - RAILS_VERSION="~> 5.0.0"
 rvm:
-  - 2.2.3
-before_install: gem install bundler -v 1.10.6
+  - 2.3.1
+before_install: gem install bundler -v 1.12.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-### 0.3.2 (unreleased)
+### 0.4.0
 * Fix be_multitenant_on matcher to handle models that don't include the `RailsMultitenant::MultitenantModel` module.
 * Fix `context_entity_id_field` to work with inheritance.
+* Drop Rails 3.2 and 4.0 support since `unscope` doesn't work propertly with default scopes.
 
 ### 0.3.1
 * Fix strip_<entity>_scope

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,3 +1,3 @@
 module RailsMultitenant
-  VERSION = '0.3.2'
+  VERSION = '0.4.0'
 end

--- a/rails_multitenant.gemspec
+++ b/rails_multitenant.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.10"
 
-  spec.add_dependency 'activerecord', ENV.fetch('RAILS_VERSION', ['>= 3.2', '< 4.3'])
-  spec.add_dependency 'activesupport', ENV.fetch('RAILS_VERSION', ['>= 3.2', '< 4.3'])
+  spec.add_dependency 'activerecord', ENV.fetch('RAILS_VERSION', ['>= 4.1', '< 5.1'])
+  spec.add_dependency 'activesupport', ENV.fetch('RAILS_VERSION', ['>= 4.1', '< 5.1'])
 
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'database_cleaner', '>= 1.2'


### PR DESCRIPTION
This PR drops support for Rails 3.2/4.0 and adds Rails 5.0 support. The `unscope` method that we depend on didn't exist in Rails 3.2 and it didn't work with the lazy evaluation of default scopes in 4.0. We could probably still get things working with the older versions of Rails but it doesn't seem worth the effort. This PR gets the Travis builds green again.

@pietdaniel - you're prime