### PR TITLE
Support use cases where organization_id may not be present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.5.0
+* Add `required` option to `multitenant_on` and `multitenant_on_model`.
+
 ### 0.4.0
 * Fix be_multitenant_on matcher to handle models that don't include the `RailsMultitenant::MultitenantModel` module.
 * Fix `context_entity_id_field` to work with inheritance.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ RailsMultitenant::GlobalContextRegistry.with_isolated_registry(organization_id: 
 end
 ```
 
+By default this adds an ActiveRecord validation to ensure the multi-tenant attribute is present but this can be disabled
+by passing `required: false` to `multitenant_on`.
+
 ### Multi-tenancy Based on Associated Models
 
 The following model is multi-tenant based on an `Organization` model:
@@ -88,6 +91,9 @@ Organization.as_current_id(1) do
   Product.all
 end
 ```
+
+By default this adds an ActiveRecord validation to ensure the tenant model is present but this can be disabled
+by passing `required: false` to `multitenant_on_model`.
 
 ## Development
 

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,3 +1,3 @@
 module RailsMultitenant
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -9,7 +9,16 @@ ActiveRecord::Schema.define(version: 0) do
     t.string :type
   end
 
+  create_table(:item_with_optional_orgs, force: true) do |t|
+    t.integer :organization_id
+    t.string :type
+  end
+
   create_table(:external_items, force: true) do |t|
+    t.integer :external_organization_id
+  end
+
+  create_table(:external_item_with_optional_orgs, force: true) do |t|
     t.integer :external_organization_id
   end
 end
@@ -23,6 +32,11 @@ class Item < ActiveRecord::Base
   multitenant_on_model :organization
 end
 
+class ItemWithOptionalOrg < ActiveRecord::Base
+  include RailsMultitenant::MultitenantModel
+  multitenant_on_model :organization, required: false
+end
+
 class ItemSubtype < Item
 
 end
@@ -30,5 +44,10 @@ end
 class ExternalItem < ActiveRecord::Base
   include RailsMultitenant::MultitenantModel
   multitenant_on :external_organization_id
+end
+
+class ExternalItemWithOptionalOrg < ActiveRecord::Base
+  include RailsMultitenant::MultitenantModel
+  multitenant_on :external_organization_id, required: false
 end
 

--- a/spec/external_item_with_optional_org_spec.rb
+++ b/spec/external_item_with_optional_org_spec.rb
@@ -1,0 +1,25 @@
+include RailsMultitenant
+
+describe ExternalItemWithOptionalOrg do
+
+  let!(:external_item_without_org) { as_external_org(nil) { described_class.create! } }
+
+  let!(:external_item_with_org) { as_external_org(1) { described_class.create! } }
+  let!(:external_item_with_other_org) { as_external_org(2) { described_class.create! } }
+
+  specify 'the nil org has the correct external items' do
+    as_external_org(nil) do
+      expect(described_class.all).to eq([external_item_without_org])
+    end
+  end
+
+  specify 'org1 has the correct external items' do
+    as_external_org(1) do
+      expect(described_class.all).to eq([external_item_with_org])
+    end
+  end
+
+  def as_external_org(id, &block)
+    GlobalContextRegistry.with_isolated_registry(external_organization_id: id, &block)
+  end
+end

--- a/spec/item_with_optional_org_spec.rb
+++ b/spec/item_with_optional_org_spec.rb
@@ -1,0 +1,26 @@
+describe ItemWithOptionalOrg do
+
+  let!(:item_without_org) { without_org { described_class.create! } }
+
+  let!(:org) { Organization.create! }
+  let!(:item_with_org) { org.as_current { described_class.create! } }
+
+  let!(:other_org) { Organization.create! }
+  let!(:item_with_other_org) { other_org.as_current { described_class.create! } }
+
+  it "returns the correct items when no org is set" do
+    without_org do
+      expect(described_class.all).to eq([item_without_org])
+    end
+  end
+
+  it "returns the correct items when an org is set" do
+    org.as_current do
+      expect(described_class.all).to eq([item_with_org])
+    end
+  end
+
+  def without_org(&block)
+    GlobalContextRegistry.with_isolated_registry(&block)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,11 @@ SimpleCov.start do
  add_filter 'spec'
 end
 
+require 'active_record'
+if ActiveRecord::VERSION::MAJOR >= 5
+  ActiveRecord::Base.belongs_to_required_by_default = true
+end
+
 require 'logger'
 require 'database_cleaner'
 require 'rails_multitenant'


### PR DESCRIPTION
This PR adds a `required` option to `multitenant_on` and `multitenant_on_model` to support use cases where a tenant id may *sometimes* be missing. An example of this is the [SalsifyKafka::Actors::Message](https://github.com/salsify/salsify_kafka/blob/master/lib/salsify_kafka/actors/message.rb) model - when processing a message for an organization the `organization_id` will be present but when processing a system message (e.g. a target schema message) an `organization_id` will not be present.

@brea9482 - Can you take a look at this? 