### PR TITLE
Optimize CurrentInstance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.5.2
+* Optimize `CurrentInstance.current` / `CurrentInstance.current_id` / `CurrentInstance.current=` 
+  / `CurrentInstance.current_id=`.
+
 ### 0.5.1
 * Fix incorrect Rails version dependency in rubygems.org.
 

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -102,15 +102,18 @@ module RailsMultitenant
         end
 
         def current_instance_registry_id
+          return @current_instance_registry_id if @current_instance_registry_id
+
           key_class = respond_to?(:base_class) ? base_class : self
-          "#{key_class.name.underscore}_id".to_sym
+          @current_instance_registry_id = "#{key_class.name.underscore}_id".to_sym
         end
 
         def current_instance_registry_obj
-          key_class = respond_to?(:base_class) ? base_class : self
-          "#{key_class.name.underscore}_obj".to_sym
-        end
+          return @current_instance_registry_obj if @current_instance_registry_obj
 
+          key_class = respond_to?(:base_class) ? base_class : self
+          @current_instance_registry_obj = "#{key_class.name.underscore}_obj".to_sym
+        end
         include RegistryDependentOn
       end
 

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,3 +1,3 @@
 module RailsMultitenant
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/rails_multitenant.gemspec
+++ b/rails_multitenant.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'database_cleaner', '>= 1.2'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '< 11.0'
   spec.add_development_dependency 'rspec', '~> 2'
   spec.add_development_dependency 'simplecov', '~> 0.7.1'
   spec.add_development_dependency 'sqlite3'


### PR DESCRIPTION
Optimize `CurrentInstance.current` / `CurrentInstance.current_id` / `CurrentInstance.current=`  / `CurrentInstance.current_id=` to memoize keys. This shaves 36% off the time for the API requests using the new describable format.

@will89 - you're prime