### PR TITLE
Add as_current class method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.7.1
+* Added as_current multi-tenant class method.
+
 ### 0.7.0
 * Add Rack middleware to create a new isolated registry per request.
 

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -60,6 +60,7 @@ module RailsMultitenant
         end
 
         def current=(object)
+          raise "#{object} is not a #{self}" if object.present? && !object.is_a?(self)
           GlobalContextRegistry.set(current_instance_registry_obj, object)
           GlobalContextRegistry.set(current_instance_registry_id, object.try(:id))
           __clear_dependents!

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -91,6 +91,10 @@ module RailsMultitenant
           self.current_id = old_id
         end
 
+        def as_current(model, &block)
+          as_current_id(model&.id, &block)
+        end
+
         def clear_current!
           GlobalContextRegistry.delete(current_instance_registry_obj)
         end

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -91,8 +91,12 @@ module RailsMultitenant
           self.current_id = old_id
         end
 
-        def as_current(model, &block)
-          as_current_id(model&.id, &block)
+        def as_current(model)
+          old_model = current
+          self.current = model
+          yield
+        ensure
+          self.current = old_model
         end
 
         def clear_current!

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,3 +1,3 @@
 module RailsMultitenant
-  VERSION = '0.7.0'
+  VERSION = '0.7.1'
 end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -30,4 +30,18 @@ describe Item do
     end
   end
 
+  describe '.as_current' do
+    it 'returns the correct items with an org supplied' do
+      Organization.as_current(org2) do
+        expect(Item.all).to eq [ item2, item3]
+      end
+    end
+
+    it 'allows a nil org to be supplied' do
+      Organization.as_current(nil) do
+        expect(Item.all).to eq []
+      end
+    end
+  end
+
 end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -42,6 +42,11 @@ describe Item do
         expect(Item.all).to eq []
       end
     end
+
+    it 'rejects models of the wrong type' do
+      model = Item.new
+      expect { Organization.as_current(model) {}}.to raise_error("#{model} is not a Organization")
+    end
   end
 
 end


### PR DESCRIPTION
`owner.as_current` works well for cases when the model owner is guaranteed to be present, but does not handle nils. I added `Owner.as_current` (similar to `Owner.as_current_id` but one less step) to better support this use case.

Prime @jturkel 