### PR TITLE
Fix clear dependents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.7.2
+* Fix bug that prevents clearing dependents of classes derived from CurrentInstance.  
+
 ### 0.7.1
 * Added as_current multi-tenant class method.
 

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -107,7 +107,8 @@ module RailsMultitenant
         private
 
         def __clear_dependents!
-          GlobalContextRegistry.send(:dependencies_for, self).each(&:clear_current!)
+          key_class = respond_to?(:base_class) ? base_class : self
+          GlobalContextRegistry.send(:dependencies_for, key_class).each(&:clear_current!)
         end
 
         def current_instance_registry_id

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,3 +1,3 @@
 module RailsMultitenant
-  VERSION = '0.7.1'
+  VERSION = '0.7.2'
 end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -4,6 +4,8 @@ ActiveRecord::Schema.define(version: 0) do
 
   create_table(:organizations, force: true)
 
+  create_table(:dependent_models, force: true)
+
   create_table(:items, force: true) do |t|
     t.integer :organization_id
     t.string :type
@@ -25,6 +27,11 @@ end
 
 class Organization < ActiveRecord::Base
   include RailsMultitenant::GlobalContextRegistry::CurrentInstance
+end
+
+class DependentModel < ActiveRecord::Base
+  include RailsMultitenant::GlobalContextRegistry::CurrentInstance
+  global_context_dependent_on Organization
 end
 
 class Item < ActiveRecord::Base

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -59,18 +59,18 @@ describe Item do
 
     it 'invalidates dependent models' do
       DependentModel.current = DependentModel.create!
-      dependent_id = DependentModel.current.object_id
+      dependent = DependentModel.current
 
       SubOrganization.create!.as_current do
-        expect(DependentModel.current.object_id).not_to eq(dependent_id)
+        expect(DependentModel.current).not_to equal(dependent)
       end
     end
 
     it 'invalidates dependent objects' do
-      dependent_id = DependentClass.current.object_id
+      dependent = DependentClass.current
 
       SubOrganization.create!.as_current do
-        expect(DependentClass.current.object_id).not_to eq(dependent_id)
+        expect(DependentClass.current).not_to equal(dependent)
       end
     end
   end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -30,6 +30,15 @@ describe Item do
     end
   end
 
+  class DependentClass
+    include RailsMultitenant::GlobalContextRegistry::Current
+    global_context_dependent_on Organization
+  end
+
+  class SubOrganization < Organization
+
+  end
+
   describe '.as_current' do
     it 'returns the correct items with an org supplied' do
       Organization.as_current(org2) do
@@ -46,6 +55,23 @@ describe Item do
     it 'rejects models of the wrong type' do
       model = Item.new
       expect { Organization.as_current(model) {}}.to raise_error("#{model} is not a Organization")
+    end
+
+    it 'invalidates dependent models' do
+      DependentModel.current = DependentModel.create!
+      dependent_id = DependentModel.current.object_id
+
+      SubOrganization.create!.as_current do
+        expect(DependentModel.current.object_id).not_to eq(dependent_id)
+      end
+    end
+
+    it 'invalidates dependent objects' do
+      dependent_id = DependentClass.current.object_id
+
+      SubOrganization.create!.as_current do
+        expect(DependentClass.current.object_id).not_to eq(dependent_id)
+      end
     end
   end
 


### PR DESCRIPTION
Fix a bug that prevents clearing dependents of classes derived from CurrentInstance.

Prime: @jturkel 