### PR TITLE
Add GlobalContextRegistry::Current.current=

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /log/
 
 bundle
+.idea
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### 0.8.1
-* Add `Current.current=`.
+* Add `Current.current=` / `Current.current?` / `Current.as_current`.
 
 ### 0.8.0
 * Switch usage of Fixnum to Integer for Ruby > 2.4 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 0.8.1 
+### 0.9.0 
 * Modify `Current.current` to return a specified default, when not already initialized, or `nil` 
   when no default is specified.    
 * Add `Current.provide_default` to optionally specify a default value for `Current.current`.    

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-### 0.8.1
-* Add `Current.current=` / `Current.current?` / `Current.as_current`.
+### 0.8.1 
+* Modify `Current.current` to return a specified default, when not already initialized, or `nil` 
+  when no default is specified.    
+* Add `Current.provide_default` to optionally specify a default value for `Current.current`.    
+* Add `Current.current=` / `Current.current?` / `Current.current!` / `Current.as_current`.
 
 ### 0.8.0
 * Switch usage of Fixnum to Integer for Ruby > 2.4 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.8.1
+* Add `Current.current=`.
+
 ### 0.8.0
 * Switch usage of Fixnum to Integer for Ruby > 2.4 
 * Test with multiple Rubies

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -39,6 +39,10 @@ module RailsMultitenant
           GlobalContextRegistry.get(current_registry_obj).present?
         end
 
+        def current!
+          current || raise("No current #{name} set")
+        end
+
         def clear_current!
           GlobalContextRegistry.delete(current_registry_obj)
         end

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -24,6 +24,10 @@ module RailsMultitenant
     module Current
       extend ActiveSupport::Concern
 
+      included do
+        class_attribute :default_provider, instance_writer: false
+      end
+
       module ClassMethods
         def current
           GlobalContextRegistry.fetch(current_registry_obj) { __current_default }
@@ -58,7 +62,7 @@ module RailsMultitenant
         include RegistryDependentOn
 
         def provide_default(provider = nil, &block)
-          @default_provider = provider ? provider.to_proc : block
+          self.default_provider = provider ? provider.to_proc : block
         end
 
         private
@@ -74,8 +78,8 @@ module RailsMultitenant
         end
 
         def __current_default
-          if @default_provider
-            default = @default_provider.call(self)
+          if self.default_provider
+            default = self.default_provider.call(self)
             raise "#{default} is not a #{self}" if default.present? && !default.is_a?(self)
             default
           end

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -58,7 +58,7 @@ module RailsMultitenant
         include RegistryDependentOn
 
         def provide_default(&default_provider)
-          Thread.current[current_registry_default_provider] = default_provider
+          @default_provider = default_provider
         end
 
         private
@@ -74,11 +74,11 @@ module RailsMultitenant
         end
 
         def __current_default
-          default_provider = Thread.current[current_registry_default_provider]
-          return nil unless default_provider
-          default = default_provider.call
-          raise "#{default} is not a #{self}" if default.present? && !default.is_a?(self)
-          default
+          if @default_provider
+            default = @default_provider.call
+            raise "#{default} is not a #{self}" if default.present? && !default.is_a?(self)
+            default
+          end
         end
 
         def __clear_dependents!

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -57,8 +57,8 @@ module RailsMultitenant
 
         include RegistryDependentOn
 
-        def provide_default(&default_provider)
-          @default_provider = default_provider
+        def provide_default(provider = nil, &block)
+          @default_provider = provider ? provider.to_proc : block
         end
 
         private
@@ -75,7 +75,7 @@ module RailsMultitenant
 
         def __current_default
           if @default_provider
-            default = @default_provider.call
+            default = @default_provider.call(self)
             raise "#{default} is not a #{self}" if default.present? && !default.is_a?(self)
             default
           end

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,3 +1,3 @@
 module RailsMultitenant
-  VERSION = '0.8.0'
+  VERSION = '0.8.1'
 end

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,3 +1,3 @@
 module RailsMultitenant
-  VERSION = '0.8.1'
+  VERSION = '0.9.0'
 end

--- a/spec/current_spec.rb
+++ b/spec/current_spec.rb
@@ -22,12 +22,23 @@ describe RailsMultitenant::GlobalContextRegistry::Current do
   end
 
   describe 'current' do
-    it 'uses default provider when supplied' do
+    it 'returns default value when supplied' do
       expect(TestClass.current.id).to eq(:default)
     end
 
-    it 'defaults to nil when no provider supplied' do
+    it 'returns nil when no default supplied' do
       expect(NoDefaultTestClass.current).to be_nil
+    end
+  end
+
+  describe 'current!' do
+    it 'returns current value when set' do
+      expect(TestClass.current.id).to eq(:default)
+    end
+
+    it 'raises an error when current not set' do
+      NoDefaultTestClass.clear_current!
+      expect { NoDefaultTestClass.current! }.to raise_error
     end
   end
 

--- a/spec/current_spec.rb
+++ b/spec/current_spec.rb
@@ -34,4 +34,60 @@ describe RailsMultitenant::GlobalContextRegistry::Current do
       expect(DependentClass.current).not_to equal(dependent)
     end
   end
+
+  describe 'current?' do
+    it 'returns false when uninitialized' do
+      TestClass.clear_current!
+      expect(TestClass.current?).to be false
+    end
+
+    it 'returns true when initialized' do
+      TestClass.current = TestClass.new
+      expect(TestClass.current?).to be true
+    end
+  end
+
+  describe 'as_current' do
+    let(:test_class1) { TestClass.new }
+    let(:test_class2) { TestClass.new }
+
+    it 'sets and restores current' do
+      TestClass.current = test_class1
+      TestClass.as_current(test_class2) do
+        expect(TestClass.current).to equal(test_class2)
+      end
+      expect(TestClass.current).to equal(test_class1)
+    end
+  end
+
+  context 'instance methods' do
+    describe 'current?' do
+      it 'returns false when not the current instance' do
+        TestClass.clear_current!
+        expect(TestClass.new.current?).to be false
+
+        TestClass.current = TestClass.new
+        expect(TestClass.new.current?).to be false
+      end
+
+      it 'returns true when it is the current instance' do
+        test_class = TestClass.new
+        TestClass.current = test_class
+        expect(test_class.current?).to be true
+      end
+    end
+
+    describe 'as_current' do
+      let(:test_class1) { TestClass.new }
+      let(:test_class2) { TestClass.new }
+
+      it 'sets and restores current' do
+        TestClass.current = test_class1
+        test_class2.as_current do
+          expect(TestClass.current).to equal(test_class2)
+        end
+        expect(TestClass.current).to equal(test_class1)
+      end
+    end
+  end
 end

--- a/spec/current_spec.rb
+++ b/spec/current_spec.rb
@@ -11,6 +11,9 @@ describe RailsMultitenant::GlobalContextRegistry::Current do
     end
   end
 
+  class SubClass < TestClass
+  end
+
   class DependentClass
     include RailsMultitenant::GlobalContextRegistry::Current
     provide_default { new }
@@ -24,6 +27,7 @@ describe RailsMultitenant::GlobalContextRegistry::Current do
   describe 'current' do
     it 'returns default value when supplied' do
       expect(TestClass.current.id).to eq(:default)
+      expect(SubClass.current.id).to eq(:default)
     end
 
     it 'returns nil when no default supplied' do

--- a/spec/current_spec.rb
+++ b/spec/current_spec.rb
@@ -1,0 +1,37 @@
+describe RailsMultitenant::GlobalContextRegistry::Current do
+
+  class TestClass
+    include RailsMultitenant::GlobalContextRegistry::Current
+
+    attr_accessor :id
+
+    def initialize(id: :default)
+      @id = id
+    end
+  end
+
+  class DependentClass
+    include RailsMultitenant::GlobalContextRegistry::Current
+    global_context_dependent_on TestClass
+  end
+
+  describe 'current' do
+    it 'default constructs the object' do
+      expect(TestClass.current.id).to eq(:default)
+    end
+  end
+
+  describe 'current=' do
+    it 'stores the provided object' do
+      provided = TestClass.new(id: :provided)
+      TestClass.current = provided
+      expect(TestClass.current).to equal(provided)
+    end
+
+    it 'clears dependencies' do
+      dependent = DependentClass.current
+      TestClass.current = TestClass.new
+      expect(DependentClass.current).not_to equal(dependent)
+    end
+  end
+end

--- a/spec/current_spec.rb
+++ b/spec/current_spec.rb
@@ -2,6 +2,7 @@ describe RailsMultitenant::GlobalContextRegistry::Current do
 
   class TestClass
     include RailsMultitenant::GlobalContextRegistry::Current
+    provide_default { new }
 
     attr_accessor :id
 
@@ -12,12 +13,21 @@ describe RailsMultitenant::GlobalContextRegistry::Current do
 
   class DependentClass
     include RailsMultitenant::GlobalContextRegistry::Current
+    provide_default { new }
     global_context_dependent_on TestClass
   end
 
+  class NoDefaultTestClass
+    include RailsMultitenant::GlobalContextRegistry::Current
+  end
+
   describe 'current' do
-    it 'default constructs the object' do
+    it 'uses default provider when supplied' do
       expect(TestClass.current.id).to eq(:default)
+    end
+
+    it 'defaults to nil when no provider supplied' do
+      expect(NoDefaultTestClass.current).to be_nil
     end
   end
 

--- a/spec/current_spec.rb
+++ b/spec/current_spec.rb
@@ -2,7 +2,7 @@ describe RailsMultitenant::GlobalContextRegistry::Current do
 
   class TestClass
     include RailsMultitenant::GlobalContextRegistry::Current
-    provide_default { new }
+    provide_default :new
 
     attr_accessor :id
 


### PR DESCRIPTION
* Modify `Current.current` to return a specified default, when not already initialized, or `nil`
  when no default is specified.
* Add `Current.provide_default` to optionally specify a default value for `Current.current`.
* Add `Current.current=` / `Current.current?` / `Current.current!` / `Current.as_current`.
* Bump version to 0.9.0