### PR TITLE
Add merge! and with_merged_registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.13.0
+* Add `RailsMultitenant::GlobalContextRegistry.merge!` and 
+` RailsMultitenant::GlobalContextRegistry.with_merged_registry`
+
 ### 0.12.0
 * Drop support for Ruby < 2.4 and Rails < 4.2.
 * Add support for Rails 6.

--- a/lib/rails_multitenant.rb
+++ b/lib/rails_multitenant.rb
@@ -9,7 +9,8 @@ require "rails_multitenant/middleware/extensions"
 module RailsMultitenant
   extend self
 
-  delegate :get, :[], :fetch, :set, :[]=, :delete, :with_isolated_registry, to: :GlobalContextRegistry
+  delegate :get, :[], :fetch, :set, :[]=, :delete, :with_isolated_registry, :merge!, :with_merged_registry,
+           to: :GlobalContextRegistry
 end
 
 # rails_multitenant/rspec has to be explicitly included by clients who want to use it

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -231,6 +231,11 @@ module RailsMultitenant
     end
     alias_method :[], :get
 
+    # merge the given values into the registry
+    def merge!(values)
+      globals.merge!(values)
+    end
+
     # Duplicate the registry
     def duplicate_registry
       globals.each_with_object({}) do |(key, value), result|
@@ -241,6 +246,14 @@ module RailsMultitenant
     # Run a block of code with an the given registry
     def with_isolated_registry(registry = {})
       prior_globals = new_registry(registry)
+      yield
+    ensure
+      self.globals = prior_globals
+    end
+
+    # Run a block of code with the given values merged into the current registry
+    def with_merged_registry(values = {})
+      prior_globals = new_registry(globals.merge(values))
       yield
     ensure
       self.globals = prior_globals

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,3 +1,3 @@
 module RailsMultitenant
-  VERSION = '0.12.0'
+  VERSION = '0.13.0'
 end

--- a/spec/rails_multitenant_spec.rb
+++ b/spec/rails_multitenant_spec.rb
@@ -48,4 +48,21 @@ describe "delegating to GlobalContextRegistry" do
 
     expect(RailsMultitenant::GlobalContextRegistry[:organization_id]).to eq('Salsify Mainland')
   end
+
+  it "RailsMultitenant.merge! adds values to the GlobalContextRegistry" do
+    RailsMultitenant::GlobalContextRegistry[:organization_id] = 'Not Salsify'
+
+    RailsMultitenant.merge!(organization_id: 'Salsify')
+
+    expect(RailsMultitenant::GlobalContextRegistry[:organization_id]).to eq('Salsify')
+  end
+
+  it "RailsMultitenant.with_merged_registry! runs the block with a merged registry" do
+    RailsMultitenant::GlobalContextRegistry[:foo] = 'bar'
+
+    RailsMultitenant.with_merged_registry(organization_id: 'Salsify') do
+      expect(RailsMultitenant::GlobalContextRegistry[:foo]).to eq('bar')
+      expect(RailsMultitenant::GlobalContextRegistry[:organization_id]).to eq('Salsify')
+    end
+  end
 end

--- a/spec/rails_multitenant_spec.rb
+++ b/spec/rails_multitenant_spec.rb
@@ -57,7 +57,7 @@ describe "delegating to GlobalContextRegistry" do
     expect(RailsMultitenant::GlobalContextRegistry[:organization_id]).to eq('Salsify')
   end
 
-  it "RailsMultitenant.with_merged_registry! runs the block with a merged registry" do
+  it "RailsMultitenant.with_merged_registry runs the block with a merged registry" do
     RailsMultitenant::GlobalContextRegistry[:foo] = 'bar'
 
     RailsMultitenant.with_merged_registry(organization_id: 'Salsify') do


### PR DESCRIPTION
This PR adds two new methods to `RailsMultitenant::GlobalContextRegistry` for some common patterns: `merge!` and `with_merged_registry`. Here are some example uses:

```ruby
# Modify the current registry
RailsMultitenant.merge!(organization_id: current_organization_id, user_id: current_user_id)

# Change the current organization for the scope of the given block
RailsMultitenant.with_merged_registry(organization_id: current_organization_id) do
  # ...
end
```
@skarger - you're prime