### PR TITLE
Remove unnecessary files

### DIFF
--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsMultitenant
-  VERSION = '0.13.0.rc1'
+  VERSION = '0.13.0'
 end

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsMultitenant
-  VERSION = '0.13.0'
+  VERSION = '0.13.0.rc1'
 end

--- a/rails_multitenant.gemspec
+++ b/rails_multitenant.gemspec
@@ -14,8 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/salsify/rails-multitenant'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.test_files    = Dir.glob('spec/**/*')
+  spec.files         = Dir['lib/**/*.rb', 'LICENSE.txt']
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.4.0'


### PR DESCRIPTION
The gem was including a bunch of unnecessary files.

Before:
```
jturkel:~/salsify/rails-multitenant → master $ gem contents rails_multitenant
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/Appraisals
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/CHANGELOG.md
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/CODE_OF_CONDUCT.md
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/Gemfile
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/LICENSE.txt
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/README.md
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/Rakefile
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/bin/console
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/bin/setup
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/gemfiles/rails_4.2.gemfile
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/gemfiles/rails_5.0.gemfile
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/gemfiles/rails_5.1.gemfile
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/gemfiles/rails_5.2.gemfile
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/gemfiles/rails_6.0.gemfile
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant/global_context_registry.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant/middleware/extensions.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant/middleware/isolated_context_registry.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant/middleware/railtie.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant/multitenant_model.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant/rspec.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant/version.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/rails_multitenant.gemspec
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/spec/be_multitenant_on_matcher_spec.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/spec/db/database.yml
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/spec/db/schema.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/spec/external_item_spec.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/spec/external_item_with_optional_org_spec.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/spec/item_spec.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/spec/item_subtype_spec.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/spec/item_with_optional_org_spec.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/spec/rails_multitenant/global_context_registry/current_spec.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/spec/rails_multitenant/global_context_registry_spec.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/spec/rails_multitenant/middleware/isolated_context_registry_spec.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/spec/rails_multitenant_spec.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/spec/spec_helper.rb
```
After:
```
jturkel:~/salsify/rails-multitenant → feature/slim-gem $ gem contents rails_multitenant
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/LICENSE.txt
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant/global_context_registry.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant/middleware/extensions.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant/middleware/isolated_context_registry.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant/middleware/railtie.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant/multitenant_model.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant/rspec.rb
/Users/jturkel/.rvm/gems/ruby-2.6.3/gems/rails_multitenant-0.13.0/lib/rails_multitenant/version.rb
```
Hopefully this is the last problem I notice with the gem today :)