### PR TITLE
Don't clear caches if we're setting current to the existing value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.13.1
+- Don't reset `current`/`current_id` when setting it the current value to avoid invalidating caches.
+
 ### 0.13.0
 * Add `RailsMultitenant::GlobalContextRegistry.merge!` and 
 ` RailsMultitenant::GlobalContextRegistry.with_merged_registry`

--- a/lib/rails_multitenant/global_context_registry/current.rb
+++ b/lib/rails_multitenant/global_context_registry/current.rb
@@ -21,6 +21,8 @@ module RailsMultitenant
 
         def current=(object)
           raise "#{object} is not a #{self}" if object.present? && !object.is_a?(self)
+          # Don't clear caches if we're setting current to the existing value
+          return if current.object_id == object.object_id
 
           GlobalContextRegistry.set(current_registry_obj, object)
           __clear_dependents!
@@ -36,6 +38,7 @@ module RailsMultitenant
 
         def clear_current!
           GlobalContextRegistry.delete(current_registry_obj)
+          __clear_dependents!
         end
 
         def as_current(object)

--- a/lib/rails_multitenant/global_context_registry/current_instance.rb
+++ b/lib/rails_multitenant/global_context_registry/current_instance.rb
@@ -13,6 +13,8 @@ module RailsMultitenant
 
       module ClassMethods
         def current_id=(id)
+          return if current_id == id
+
           GlobalContextRegistry.delete(current_instance_registry_obj)
           GlobalContextRegistry.set(current_instance_registry_id, id)
           __clear_dependents!
@@ -20,6 +22,8 @@ module RailsMultitenant
 
         def current=(object)
           raise "#{object} is not a #{self}" if object.present? && !object.is_a?(self)
+          # Don't clear caches if we're setting current to the existing value
+          return if GlobalContextRegistry.get(current_instance_registry_obj).object_id == object.object_id
 
           GlobalContextRegistry.set(current_instance_registry_obj, object)
           GlobalContextRegistry.set(current_instance_registry_id, object.try(:id))
@@ -62,6 +66,8 @@ module RailsMultitenant
 
         def clear_current!
           GlobalContextRegistry.delete(current_instance_registry_obj)
+          GlobalContextRegistry.delete(current_instance_registry_id)
+          __clear_dependents!
         end
 
         private

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsMultitenant
-  VERSION = '0.13.0'
+  VERSION = '0.13.1'
 end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -7,7 +7,7 @@
 describe Item do
 
   let!(:item1) { Item.create! }
-
+  let!(:org1) { Organization.current! }
   let!(:org2) { Organization.create! }
   let!(:item2) { org2.as_current { Item.create! } }
   let!(:item3) { org2.as_current { Item.create! } }
@@ -41,6 +41,55 @@ describe Item do
 
   end
 
+  describe ".current_id=" do
+    before do
+      Organization.current = org1
+    end
+
+    it "invalidates the cached object" do
+      Organization.current_id = org2.id
+      expect(Organization.current).to eq(org2)
+    end
+
+    it "invalidates the cached id" do
+      Organization.current_id = org2.id
+      expect(Organization.current_id).to eq(org2.id)
+    end
+
+    it "doesn't clear the cached object when set to the same current_id" do
+      allow(Organization).to receive(:find).and_raise("Shouldn't be called")
+      Organization.current_id = org1.id
+      expect(Organization.current).to equal(org1)
+    end
+  end
+
+  describe ".current=" do
+    before do
+      Organization.current = org1
+    end
+
+    it "invalidates the cached object" do
+      Organization.current = org2
+      expect(Organization.current).to eq(org2)
+    end
+
+    it "invalidates the cached id" do
+      Organization.current = org2
+      expect(Organization.current_id).to eq(org2.id)
+    end
+
+    it "doesn't clear the cached object when set to the same current" do
+      allow(Organization).to receive(:find).and_raise("Shouldn't be called")
+      Organization.current = org1
+      expect(Organization.current).to equal(org1)
+    end
+
+    it "clears the cached object when set to a different instance of current" do
+      Organization.current = Organization.find(Organization.current_id)
+      expect(Organization.current).not_to equal(org1)
+    end
+  end
+
   describe ".as_current" do
     it "returns the correct items with an org supplied" do
       Organization.as_current(org2) do
@@ -60,8 +109,8 @@ describe Item do
     end
 
     it "invalidates dependent models" do
-      DependentModel.current = DependentModel.create!
-      dependent = DependentModel.current
+      dependent = DependentModel.create!
+      DependentModel.current = dependent
 
       SubOrganization.create!.as_current do
         expect(DependentModel.current).not_to equal(dependent)
@@ -69,7 +118,8 @@ describe Item do
     end
 
     it "invalidates dependent objects" do
-      dependent = DependentClass.current
+      dependent = DependentClass.new
+      DependentClass.current = dependent
 
       SubOrganization.create!.as_current do
         expect(DependentClass.current).not_to equal(dependent)
@@ -77,4 +127,29 @@ describe Item do
     end
   end
 
+  describe ".clear_current!" do
+    let(:dependent) { DependentModel.create! }
+
+    before do
+      Organization.current = org2
+      DependentModel.current = dependent
+      Organization.clear_current!
+    end
+
+    it "clears the current object" do
+      expect(Organization.current).to be_nil
+    end
+
+    it "clears the current id" do
+      expect(Organization.current_id).to be_nil
+    end
+
+    it "clears the dependent current object" do
+      expect(DependentModel.current).to be_nil
+    end
+
+    it "clears the dependent current id" do
+      expect(DependentModel.current_id).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
This PR updates `current=` and `current_id=` to be no-ops if setting current to the existing value which avoids clearing any caches. It also fixes `clear_current!` to ensure they propagate to dependent objects.

@atsheehan - you're prime