### PR TITLE
Add a way to ignore scopes when querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-### 0.13.1
+### 0.14.0
 * Add `RailsMultitenant::GlobalContextRegistry.with_admin_scope` - queries executed within the block will skip scoping
+* Add `RailsMultitenant::GlobalContextRegistry.enable_admin_registry` and `RailsMultitenant::GlobalContextRegistry.disable_admin_registry` - Methods for skipping and resuming scoping when blocks are not usable
 
 ### 0.13.0
 * Add `RailsMultitenant::GlobalContextRegistry.merge!` and 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.13.1
+* Add `RailsMultitenant::GlobalContextRegistry.with_admin_scope` - queries executed within the block will skip scoping
+
 ### 0.13.0
 * Add `RailsMultitenant::GlobalContextRegistry.merge!` and 
 ` RailsMultitenant::GlobalContextRegistry.with_merged_registry`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ### 0.14.0
-* Add `RailsMultitenant::GlobalContextRegistry.with_admin_scope` - queries executed within the block will skip scoping
-* Add `RailsMultitenant::GlobalContextRegistry.enable_admin_registry` and `RailsMultitenant::GlobalContextRegistry.disable_admin_registry` - Methods for skipping and resuming scoping when blocks are not usable
+* Add `RailsMultitenant::GlobalContextRegistry.with_unscoped_queries` - queries executed within the block will skip scoping
+* Add `RailsMultitenant::GlobalContextRegistry.disable_scoped_queries` and `RailsMultitenant::GlobalContextRegistry.enable_scoped_queries` - Methods for skipping and resuming scoping when blocks are not usable
 
 ### 0.13.0
 * Add `RailsMultitenant::GlobalContextRegistry.merge!` and 

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -87,9 +87,13 @@ module RailsMultitenant
 
     # Run a block of code that disregards scoping during read queries
     def with_unscoped_queries
-      with_merged_registry(use_unscoped_queries: true) do
+      with_merged_registry(__use_unscoped_queries: true) do
         yield
       end
+    end
+
+    def use_unscoped_queries?
+      self[:__use_unscoped_queries] == true
     end
 
     # Prefer .with_unscoped_queries to the following two methods.
@@ -97,11 +101,11 @@ module RailsMultitenant
     # but in contexts where around semantics are not allowed.
 
     def disable_scoped_queries
-      self[:use_unscoped_queries] = true
+      self[:__use_unscoped_queries] = true
     end
 
     def enable_scoped_queries
-      self[:use_unscoped_queries] = nil
+      self[:__use_unscoped_queries] = nil
     end
 
     private

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -86,24 +86,22 @@ module RailsMultitenant
     end
 
     # Run a block of code that disregards scoping during read queries
-    def with_admin_registry
-      puts globals
-      prior_globals = new_registry(globals.merge(admin_registry_enabled: true))
-      yield
-    ensure
-      self.globals = prior_globals
+    def with_unscoped_queries
+      with_merged_registry(use_unscoped_queries: true) do
+        yield
+      end
     end
 
-    # Prefer .with_admin_registry to the following two methods.
+    # Prefer .with_unscoped_queries to the following two methods.
     # Note: these methods are intended for use in a manner like .with_admin_registry,
     # but in contexts where around semantics are not allowed.
 
-    def enable_admin_registry
-      self[:admin_registry_enabled] = true
+    def disable_scoped_queries
+      self[:use_unscoped_queries] = true
     end
 
-    def disable_admin_registry
-      self[:admin_registry_enabled] = nil
+    def enable_scoped_queries
+      self[:use_unscoped_queries] = nil
     end
 
     private

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -69,6 +69,15 @@ module RailsMultitenant
       self.globals = prior_globals
     end
 
+    # Run a block of code that disregards scoping during read queries
+    def with_admin_registry
+      puts globals
+      prior_globals = new_registry(globals.merge(admin_registry_enabled: true))
+      yield
+    ensure
+      self.globals = prior_globals
+    end
+
     # Prefer .with_isolated_registry to the following two methods.
     # Note: these methods are intended for use in a manner like .with_isolated_registry,
     # but in contexts where around semantics are not allowed.

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -98,11 +98,11 @@ module RailsMultitenant
     # Note: these methods are intended for use in a manner like .with_admin_registry,
     # but in contexts where around semantics are not allowed.
 
-    def enable_admin
+    def enable_admin_registry
       self[:admin_registry_enabled] = true
     end
 
-    def disable_admin
+    def disable_admin_registry
       self[:admin_registry_enabled] = nil
     end
 

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -69,15 +69,6 @@ module RailsMultitenant
       self.globals = prior_globals
     end
 
-    # Run a block of code that disregards scoping during read queries
-    def with_admin_registry
-      puts globals
-      prior_globals = new_registry(globals.merge(admin_registry_enabled: true))
-      yield
-    ensure
-      self.globals = prior_globals
-    end
-
     # Prefer .with_isolated_registry to the following two methods.
     # Note: these methods are intended for use in a manner like .with_isolated_registry,
     # but in contexts where around semantics are not allowed.
@@ -92,6 +83,27 @@ module RailsMultitenant
     # Replace the registry with one you previously took away with .new_registry
     def replace_registry(registry)
       self.globals = registry
+    end
+
+    # Run a block of code that disregards scoping during read queries
+    def with_admin_registry
+      puts globals
+      prior_globals = new_registry(globals.merge(admin_registry_enabled: true))
+      yield
+    ensure
+      self.globals = prior_globals
+    end
+
+    # Prefer .with_admin_registry to the following two methods.
+    # Note: these methods are intended for use in a manner like .with_admin_registry,
+    # but in contexts where around semantics are not allowed.
+
+    def enable_admin
+      self[:admin_registry_enabled] = true
+    end
+
+    def disable_admin
+      self[:admin_registry_enabled] = nil
     end
 
     private

--- a/lib/rails_multitenant/multitenant_model.rb
+++ b/lib/rails_multitenant/multitenant_model.rb
@@ -18,7 +18,7 @@ module RailsMultitenant
         scope_sym = "from_current_#{context_entity}".to_sym
 
         scope scope_sym, -> do
-          unless GlobalContextRegistry[:admin_registry_enabled]
+          unless GlobalContextRegistry[:use_unscoped_queries]
             where(context_entity_id_field => GlobalContextRegistry[context_entity_id_field])
           end
         end

--- a/lib/rails_multitenant/multitenant_model.rb
+++ b/lib/rails_multitenant/multitenant_model.rb
@@ -18,7 +18,7 @@ module RailsMultitenant
         scope_sym = "from_current_#{context_entity}".to_sym
 
         scope scope_sym, -> do
-          unless GlobalContextRegistry[:use_unscoped_queries]
+          unless GlobalContextRegistry.use_unscoped_queries?
             where(context_entity_id_field => GlobalContextRegistry[context_entity_id_field])
           end
         end

--- a/lib/rails_multitenant/multitenant_model.rb
+++ b/lib/rails_multitenant/multitenant_model.rb
@@ -18,7 +18,9 @@ module RailsMultitenant
         scope_sym = "from_current_#{context_entity}".to_sym
 
         scope scope_sym, -> do
-          where(context_entity_id_field => GlobalContextRegistry[context_entity_id_field])
+          unless GlobalContextRegistry[:admin_registry_enabled]
+            where(context_entity_id_field => GlobalContextRegistry[context_entity_id_field])
+          end
         end
 
         default_scope { send(scope_sym) }

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsMultitenant
-  VERSION = '0.13.1'
+  VERSION = '0.14.0'
 end

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsMultitenant
-  VERSION = '0.13.0'
+  VERSION = '0.13.1'
 end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -20,6 +20,12 @@ describe Item do
     expect(Item.where(id: item2.id)).to eq []
   end
 
+  it "does return item2 when in admin mode" do
+    RailsMultitenant::GlobalContextRegistry.with_admin_registry do
+      expect(Item.where(id: item2.id)).to eq [item2]
+    end
+  end
+
   specify "org2 should have two items" do
     org2.as_current do
       expect(Item.all).to eq [item2, item3]

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -20,10 +20,18 @@ describe Item do
     expect(Item.where(id: item2.id)).to eq []
   end
 
-  it "does return item2 when in admin mode" do
+  it "behaves correctly when using an admin registry block" do
     RailsMultitenant::GlobalContextRegistry.with_admin_registry do
       expect(Item.where(id: item2.id)).to eq [item2]
     end
+    expect(Item.where(id: item2.id)).to eq []
+  end
+
+  it "behaves correctly when using admin registry without a block" do
+    RailsMultitenant::GlobalContextRegistry.enable_admin_registry
+    expect(Item.where(id: item2.id)).to eq [item2]
+    RailsMultitenant::GlobalContextRegistry.disable_admin_registry
+    expect(Item.where(id: item2.id)).to eq []
   end
 
   specify "org2 should have two items" do

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -20,17 +20,17 @@ describe Item do
     expect(Item.where(id: item2.id)).to eq []
   end
 
-  it "behaves correctly when using an admin registry block" do
-    RailsMultitenant::GlobalContextRegistry.with_admin_registry do
+  it "behaves correctly when disabling scoping with a block" do
+    RailsMultitenant::GlobalContextRegistry.with_unscoped_queries do
       expect(Item.where(id: item2.id)).to eq [item2]
     end
     expect(Item.where(id: item2.id)).to eq []
   end
 
-  it "behaves correctly when using admin registry without a block" do
-    RailsMultitenant::GlobalContextRegistry.enable_admin_registry
+  it "behaves correctly when disabling and enabling scoping without a block" do
+    RailsMultitenant::GlobalContextRegistry.disable_scoped_queries
     expect(Item.where(id: item2.id)).to eq [item2]
-    RailsMultitenant::GlobalContextRegistry.disable_admin_registry
+    RailsMultitenant::GlobalContextRegistry.enable_scoped_queries
     expect(Item.where(id: item2.id)).to eq []
   end
 

--- a/spec/rails_multitenant/global_context_registry_spec.rb
+++ b/spec/rails_multitenant/global_context_registry_spec.rb
@@ -163,7 +163,7 @@ describe RailsMultitenant::GlobalContextRegistry do
     end
   end
 
-  describe ".with_admin_registry" do
+  describe ".with_unscoped_queries" do
     it "yields to the provided block" do
       expect { |b| RailsMultitenant::GlobalContextRegistry.with_unscoped_queries(&b) }.to yield_control
     end

--- a/spec/rails_multitenant/global_context_registry_spec.rb
+++ b/spec/rails_multitenant/global_context_registry_spec.rb
@@ -165,7 +165,7 @@ describe RailsMultitenant::GlobalContextRegistry do
 
   describe ".with_admin_registry" do
     it "yields to the provided block" do
-      expect { |b| RailsMultitenant::GlobalContextRegistry.with_admin_registry(&b) }.to yield_control
+      expect { |b| RailsMultitenant::GlobalContextRegistry.with_unscoped_queries(&b) }.to yield_control
     end
   end
 end

--- a/spec/rails_multitenant/global_context_registry_spec.rb
+++ b/spec/rails_multitenant/global_context_registry_spec.rb
@@ -162,4 +162,10 @@ describe RailsMultitenant::GlobalContextRegistry do
       expect(RailsMultitenant::GlobalContextRegistry.get(:team)).to eq('Patriots')
     end
   end
+
+  describe ".with_admin_registry" do
+    it "yields to the provided block" do
+      expect { |b| RailsMultitenant::GlobalContextRegistry.with_admin_registry(&b) }.to yield_control
+    end
+  end
 end

--- a/spec/rails_multitenant_spec.rb
+++ b/spec/rails_multitenant_spec.rb
@@ -68,14 +68,26 @@ describe "delegating to GlobalContextRegistry" do
     end
   end
 
-  it "RailsMultitenant.with_admin_registry enables admin mode without removing existing context" do
+  it "RailsMultitenant.with_unscoped_queries does not remove existing context" do
     RailsMultitenant::GlobalContextRegistry[:organization_id] = 'Salsify'
 
-    RailsMultitenant::GlobalContextRegistry.with_admin_registry do
-      expect(RailsMultitenant::GlobalContextRegistry[:admin_registry_enabled]).to be_truthy
+    RailsMultitenant::GlobalContextRegistry.with_unscoped_queries do
+      expect(RailsMultitenant::GlobalContextRegistry[:use_unscoped_queries]).to be_truthy
       expect(RailsMultitenant::GlobalContextRegistry[:organization_id]).to eq('Salsify')
     end
 
-    expect(RailsMultitenant::GlobalContextRegistry[:admin_registry_enabled]).to be_falsey
+    expect(RailsMultitenant::GlobalContextRegistry[:use_unscoped_queries]).to be_falsey
+  end
+
+  it "RailsMultitenant.disabled_scoped_queries and RailsMultitenant.enable_scoped_queries do not impact existing context" do
+    RailsMultitenant::GlobalContextRegistry[:organization_id] = 'Salsify'
+
+    RailsMultitenant::GlobalContextRegistry.disable_scoped_queries
+    expect(RailsMultitenant::GlobalContextRegistry[:use_unscoped_queries]).to be_truthy
+    expect(RailsMultitenant::GlobalContextRegistry[:organization_id]).to eq('Salsify')
+
+    RailsMultitenant::GlobalContextRegistry.enable_scoped_queries
+    expect(RailsMultitenant::GlobalContextRegistry[:use_unscoped_queries]).to be_falsey
+    expect(RailsMultitenant::GlobalContextRegistry[:organization_id]).to eq('Salsify')
   end
 end

--- a/spec/rails_multitenant_spec.rb
+++ b/spec/rails_multitenant_spec.rb
@@ -79,7 +79,7 @@ describe "delegating to GlobalContextRegistry" do
     expect(RailsMultitenant::GlobalContextRegistry[:use_unscoped_queries]).to be_falsey
   end
 
-  it "RailsMultitenant.disabled_scoped_queries and RailsMultitenant.enable_scoped_queries do not impact existing context" do
+  it "RailsMultitenant.disabled_scoped_queries and enable_scoped_queries do not impact existing context" do
     RailsMultitenant::GlobalContextRegistry[:organization_id] = 'Salsify'
 
     RailsMultitenant::GlobalContextRegistry.disable_scoped_queries

--- a/spec/rails_multitenant_spec.rb
+++ b/spec/rails_multitenant_spec.rb
@@ -67,4 +67,15 @@ describe "delegating to GlobalContextRegistry" do
       expect(RailsMultitenant::GlobalContextRegistry[:organization_id]).to eq('Salsify')
     end
   end
+
+  it "RailsMultitenant.with_admin_registry enables admin mode without removing existing context" do
+    RailsMultitenant::GlobalContextRegistry[:organization_id] = 'Salsify'
+
+    RailsMultitenant::GlobalContextRegistry.with_admin_registry do
+      expect(RailsMultitenant::GlobalContextRegistry[:admin_registry_enabled]).to be_truthy
+      expect(RailsMultitenant::GlobalContextRegistry[:organization_id]).to eq('Salsify')
+    end
+
+    expect(RailsMultitenant::GlobalContextRegistry[:admin_registry_enabled]).to be_falsey
+  end
 end

--- a/spec/rails_multitenant_spec.rb
+++ b/spec/rails_multitenant_spec.rb
@@ -72,22 +72,22 @@ describe "delegating to GlobalContextRegistry" do
     RailsMultitenant::GlobalContextRegistry[:organization_id] = 'Salsify'
 
     RailsMultitenant::GlobalContextRegistry.with_unscoped_queries do
-      expect(RailsMultitenant::GlobalContextRegistry[:use_unscoped_queries]).to be_truthy
+      expect(RailsMultitenant::GlobalContextRegistry.use_unscoped_queries?).to eq true
       expect(RailsMultitenant::GlobalContextRegistry[:organization_id]).to eq('Salsify')
     end
 
-    expect(RailsMultitenant::GlobalContextRegistry[:use_unscoped_queries]).to be_falsey
+    expect(RailsMultitenant::GlobalContextRegistry.use_unscoped_queries?).to eq false
   end
 
   it "RailsMultitenant.disabled_scoped_queries and enable_scoped_queries do not impact existing context" do
     RailsMultitenant::GlobalContextRegistry[:organization_id] = 'Salsify'
 
     RailsMultitenant::GlobalContextRegistry.disable_scoped_queries
-    expect(RailsMultitenant::GlobalContextRegistry[:use_unscoped_queries]).to be_truthy
+    expect(RailsMultitenant::GlobalContextRegistry.use_unscoped_queries?).to eq true
     expect(RailsMultitenant::GlobalContextRegistry[:organization_id]).to eq('Salsify')
 
     RailsMultitenant::GlobalContextRegistry.enable_scoped_queries
-    expect(RailsMultitenant::GlobalContextRegistry[:use_unscoped_queries]).to be_falsey
+    expect(RailsMultitenant::GlobalContextRegistry.use_unscoped_queries?).to eq false
     expect(RailsMultitenant::GlobalContextRegistry[:organization_id]).to eq('Salsify')
   end
 end


### PR DESCRIPTION
Problem: When using ActiveAdmin for managing org scoped data, it is often not possible to strip all scopes, especially when using related models.

Solution: Add a way to turn off scoping for queries. There are three new methods - one that disables scoping for a block, and two that will toggle scoping off and on for when using a block isn't possible.

prime: @jturkel 