### PR TITLE
Fix Rubocop CI Configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
             - "gemfiles/vendor/bundle"
       - run:
           name: Run Rubocop
-          command: bundle exec rubocop .rubocop.yml
+          command: bundle exec rubocop --config .rubocop.yml
   test:
     parameters:
       gemfile:


### PR DESCRIPTION
This PR fixes the Rubocop CI configuration which was only linting `.rubocop.yml` 🤦 