### PR TITLE
Store Registry Dependencies by Class Name to Support Reloadable Classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.18.0
+* Added better support for registry dependencies in a development environment where classes may be reloaded.
+* Added a `global_context_dependent_with` method to support registering bidirectional references.
+
 ### 0.17.0
 * Add support for Ruby 3.2.
 * Drop support for Rails 5.2.
@@ -17,7 +21,7 @@
 * Add `RailsMultitenant::GlobalContextRegistry.disable_scoped_queries` and `RailsMultitenant::GlobalContextRegistry.enable_scoped_queries` - Methods for skipping and resuming scoping when blocks are not usable
 
 ### 0.13.0
-* Add `RailsMultitenant::GlobalContextRegistry.merge!` and 
+* Add `RailsMultitenant::GlobalContextRegistry.merge!` and
 ` RailsMultitenant::GlobalContextRegistry.with_merged_registry`
 
 ### 0.12.0
@@ -33,8 +37,8 @@
 
 ### 0.9.0
 * Modify `Current.current` to return a specified default, when not already initialized, or `nil`
-  when no default is specified.    
-* Add `Current.provide_default` to optionally specify a default value for `Current.current`.    
+  when no default is specified.
+* Add `Current.provide_default` to optionally specify a default value for `Current.current`.
 * Add `Current.current=` / `Current.current?` / `Current.current!` / `Current.as_current`.
 
 ### 0.8.0
@@ -42,7 +46,7 @@
 * Test with multiple Rubies
 
 ### 0.7.2
-* Fix bug that prevents clearing dependents of classes derived from CurrentInstance.  
+* Fix bug that prevents clearing dependents of classes derived from CurrentInstance.
 
 ### 0.7.1
 * Added as_current multi-tenant class method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.18.0
 * Add better support for registry dependencies in a development environment where classes may be reloaded.
-* Add a `global_context_dependent_with` method to support registering bidirectional references.
+* Add a `global_context_mutually_dependent_on` method to support registering bidirectional references.
 
 ### 0.17.0
 * Add support for Ruby 3.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ### 0.18.0
-* Added better support for registry dependencies in a development environment where classes may be reloaded.
-* Added a `global_context_dependent_with` method to support registering bidirectional references.
+* Add better support for registry dependencies in a development environment where classes may be reloaded.
+* Add a `global_context_dependent_with` method to support registering bidirectional references.
 
 ### 0.17.0
 * Add support for Ruby 3.2.

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -14,6 +14,8 @@ module RailsMultitenant
   module GlobalContextRegistry
     extend self
 
+    EMPTY_ARRAY = [].freeze
+
     # Set this global
     def set(symbol, value)
       globals[symbol] = value
@@ -114,13 +116,16 @@ module RailsMultitenant
     @dependencies = {}
 
     def add_dependency(parent, dependent)
-      raise 'dependencies cannot be registered for anonymous classes' if parent.name.blank? || dependent.name.blank?
+      parent = parent.respond_to?(:name) ? parent.name : parent
+      dependent = dependent.respond_to?(:name) ? dependent.name : dependent
 
-      ((@dependencies[parent.name] ||= []) << dependent.name).tap(&:uniq!)
+      raise 'dependencies cannot be registered for anonymous classes' if parent.blank? || dependent.blank?
+
+      ((@dependencies[parent] ||= []) << dependent).tap(&:uniq!)
     end
 
     def dependencies_for(klass)
-      @dependencies[klass.name]&.map(&:safe_constantize)&.tap(&:compact!) || []
+      @dependencies[klass.name]&.map(&:safe_constantize)&.tap(&:compact!) || EMPTY_ARRAY
     end
 
     def globals

--- a/lib/rails_multitenant/global_context_registry.rb
+++ b/lib/rails_multitenant/global_context_registry.rb
@@ -114,11 +114,13 @@ module RailsMultitenant
     @dependencies = {}
 
     def add_dependency(parent, dependent)
-      (@dependencies[parent] ||= []) << dependent
+      raise 'dependencies cannot be registered for anonymous classes' if parent.name.blank? || dependent.name.blank?
+
+      ((@dependencies[parent.name] ||= []) << dependent.name).tap(&:uniq!)
     end
 
     def dependencies_for(klass)
-      @dependencies[klass] || []
+      @dependencies[klass.name]&.map(&:safe_constantize)&.tap(&:compact!) || []
     end
 
     def globals

--- a/lib/rails_multitenant/global_context_registry/registry_dependent_on.rb
+++ b/lib/rails_multitenant/global_context_registry/registry_dependent_on.rb
@@ -10,7 +10,7 @@ module RailsMultitenant
       end
 
       # Registers a bi-directional dependency on another class.
-      def global_context_dependent_with(*klasses)
+      def global_context_mutually_dependent_on(*klasses)
         global_context_dependent_on(*klasses)
         klasses.each { |klass| klass.global_context_dependent_on(self) }
       end

--- a/lib/rails_multitenant/global_context_registry/registry_dependent_on.rb
+++ b/lib/rails_multitenant/global_context_registry/registry_dependent_on.rb
@@ -8,6 +8,12 @@ module RailsMultitenant
       def global_context_dependent_on(*klasses)
         klasses.each { |klass| GlobalContextRegistry.send(:add_dependency, klass, self) }
       end
+
+      # Registers a bi-directional dependency on another class.
+      def global_context_dependent_with(*klasses)
+        global_context_dependent_on(*klasses)
+        klasses.each { |klass| klass.global_context_dependent_on(self) }
+      end
     end
   end
 end

--- a/lib/rails_multitenant/version.rb
+++ b/lib/rails_multitenant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsMultitenant
-  VERSION = '0.17.0'
+  VERSION = '0.18.0'
 end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -16,15 +16,10 @@ describe Item do
   let!(:item3) { org2.as_current { Item.create! } }
 
   before do
-    Object.const_set(:DependentClass, dependent_class)
-    Object.const_set(:SubOrganization, Class.new(Organization))
+    stub_const('DependentClass', dependent_class)
+    stub_const('SubOrganization', Class.new(Organization))
 
     DependentClass.global_context_dependent_on Organization
-  end
-
-  after do
-    Object.send(:remove_const, :DependentClass)
-    Object.send(:remove_const, :SubOrganization)
   end
 
   specify "default org should have one item" do

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -8,27 +8,24 @@ describe Item do
 
   let!(:item1) { Item.create! }
   let(:dependent_class) do
-    Class.new do
-      include RailsMultitenant::GlobalContextRegistry::Current
-      global_context_dependent_on Organization
-
-      def self.name
-        'DependentClass'
-      end
-    end
-  end
-
-  let(:sub_organization) do
-    Class.new(Organization) do
-      def self.name
-        'SubOrganization'
-      end
-    end
+    Class.new { include RailsMultitenant::GlobalContextRegistry::Current }
   end
 
   let!(:org2) { Organization.create! }
   let!(:item2) { org2.as_current { Item.create! } }
   let!(:item3) { org2.as_current { Item.create! } }
+
+  before do
+    Object.const_set('DependentClass', dependent_class)
+    Object.const_set('SubOrganization', Class.new(Organization))
+
+    DependentClass.global_context_dependent_on Organization
+  end
+
+  after do
+    Object.send(:remove_const, :DependentClass)
+    Object.send(:remove_const, :SubOrganization)
+  end
 
   specify "default org should have one item" do
     expect(Item.all).to eq [item1]
@@ -86,17 +83,17 @@ describe Item do
       DependentModel.current = DependentModel.create!
       dependent = DependentModel.current
 
-      sub_organization.create!.as_current do
+      SubOrganization.create!.as_current do
         expect(DependentModel.current).not_to equal(dependent)
       end
     end
 
     it "invalidates dependent objects" do
-      dependent = dependent_class.new
-      dependent_class.current = dependent
+      dependent = DependentClass.new
+      DependentClass.current = dependent
 
-      sub_organization.create!.as_current do
-        expect(dependent_class.current).not_to equal(dependent)
+      SubOrganization.create!.as_current do
+        expect(DependentClass.current).not_to equal(dependent)
       end
     end
   end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -16,8 +16,8 @@ describe Item do
   let!(:item3) { org2.as_current { Item.create! } }
 
   before do
-    Object.const_set('DependentClass', dependent_class)
-    Object.const_set('SubOrganization', Class.new(Organization))
+    Object.const_set(:DependentClass, dependent_class)
+    Object.const_set(:SubOrganization, Class.new(Organization))
 
     DependentClass.global_context_dependent_on Organization
   end

--- a/spec/rails_multitenant/global_context_registry/current_spec.rb
+++ b/spec/rails_multitenant/global_context_registry/current_spec.rb
@@ -13,10 +13,10 @@ end
 
 describe RailsMultitenant::GlobalContextRegistry::Current do
   before do
-    Object.const_set('SubClass', Class.new(TestClass))
-    Object.const_set('DependentClass', dependent_class)
-    Object.const_set('BiDependentClass', bidependent_class)
-    Object.const_set('NoDefaultTestClass', no_default_test_class)
+    Object.const_set(:SubClass, Class.new(TestClass))
+    Object.const_set(:DependentClass, dependent_class)
+    Object.const_set(:BiDependentClass, bidependent_class)
+    Object.const_set(:NoDefaultTestClass, no_default_test_class)
 
     DependentClass.global_context_dependent_on TestClass
     BiDependentClass.global_context_dependent_with TestClass

--- a/spec/rails_multitenant/global_context_registry/current_spec.rb
+++ b/spec/rails_multitenant/global_context_registry/current_spec.rb
@@ -13,20 +13,13 @@ end
 
 describe RailsMultitenant::GlobalContextRegistry::Current do
   before do
-    Object.const_set(:SubClass, Class.new(TestClass))
-    Object.const_set(:DependentClass, dependent_class)
-    Object.const_set(:BiDependentClass, bidependent_class)
-    Object.const_set(:NoDefaultTestClass, no_default_test_class)
+    stub_const('SubClass', Class.new(TestClass))
+    stub_const('DependentClass', dependent_class)
+    stub_const('BiDependentClass', bidependent_class)
+    stub_const('NoDefaultTestClass', no_default_test_class)
 
     DependentClass.global_context_dependent_on TestClass
-    BiDependentClass.global_context_dependent_with TestClass
-  end
-
-  after do
-    Object.send(:remove_const, :SubClass)
-    Object.send(:remove_const, :DependentClass)
-    Object.send(:remove_const, :BiDependentClass)
-    Object.send(:remove_const, :NoDefaultTestClass)
+    BiDependentClass.global_context_mutually_dependent_on TestClass
   end
 
   let(:dependent_class) do


### PR DESCRIPTION
Previously the dependency registry stored references using the actual class objects. This generally worked in development simply because we ended up with new registry dependencies when classes were reloaded. It would not work, however, if you had a reference from a reloadable class to a non-reloadable class, since the reference would disappear if the referencing class was reloaded. This fell out of a conversion here: https://github.com/salsify/salsify-organizations/pull/2#discussion_r1089370779

Instead, store dependencies by class name and resolve them to the actual class when they're accessed.

While I was in here I also added a helper for registering bi-directional references, `global_context_mutually_dependent_on`.

The only downside is that we can no longer have dependencies on anonymous classes. I don't see anywhere that we're actually doing this in app-code. They only place was in the tests for `Current`, which I updated.

With this change in Dandelion:
```
dandelion(dev)(writable):001:0> RailsMultitenant::GlobalContextRegistry.instance_variable_get(:@dependencies)
=> {"Organization"=>["Catalog", "AssetService", "OrganizationMembership"], "Security::User"=>["OrganizationMembership"]}
dandelion(dev)(writable):002:0> reload!
Reloading...
=> true
dandelion(dev)(writable):003:0> RailsMultitenant::GlobalContextRegistry.instance_variable_get(:@dependencies)
=> {"Organization"=>["Catalog", "AssetService", "OrganizationMembership"], "Security::User"=>["OrganizationMembership"]}
```

prime: @jturkel 