### PR TITLE
Bump SQLite

### DIFF
--- a/rails_multitenant.gemspec
+++ b/rails_multitenant.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'salsify_rubocop', '~> 1.27.1'
   spec.add_development_dependency 'simplecov', '~> 0.15.1'
-  spec.add_development_dependency 'sqlite3', '~> 1.4.0'
+  spec.add_development_dependency 'sqlite3', '~> 1.6.0'
 end


### PR DESCRIPTION
This bumps the version of the SQLite client we're using, primarily so that we can get a precompiled version and avoid having to manually install sqlite headers in our library-release dockerfile.

prime: @joshbranham 